### PR TITLE
GPS 주기정보에 분(minute) 필드 추가로 타임스탬프 오류 해결

### DIFF
--- a/models/emulator_data.py
+++ b/models/emulator_data.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 from datetime import datetime
 
 class GpsLogItem(BaseModel):
+    min: str = Field(..., description="분 단위 시간")
     sec: str = Field(..., description="초 단위 시간")
     gcd: str = Field(..., description="GPS 좌표계 코드")
     lat: str = Field(..., description="위도")

--- a/services/log_generators/gps_log_generator.py
+++ b/services/log_generators/gps_log_generator.py
@@ -183,11 +183,13 @@ class GpsLogGenerator(BaseLogGenerator):
             lat_value = round(data.get("latitude", 0), 6)
             lon_value = round(data.get("longitude", 0), 6)
 
-            # 타임스탬프에서 초 정보 추출
+            # 타임스탬프에서 분, 초 정보 추출
             timestamp = data.get("timestamp")
+            minutes = timestamp.minute if timestamp else 0
             seconds = timestamp.second if timestamp else i
 
             log_item = GpsLogItem(
+                min=str(minutes),
                 sec=str(seconds),
                 gcd="A",  # 기본값 A (정상)
                 lat=str(int(lat_value * 1000000)),  # 소수점 6자리로 제한하고 1,000,000 곱하기


### PR DESCRIPTION


### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 버그 수정

### 📌 관련 이슈
#14 

### ✨ 반영 브랜치
ex) feat/14 -> main

## 문제 상황
- 분 경계를 넘어갈 때 백엔드에서 타임스탬프가 잘못 재구성되는 문제 발생
- 예: 10:36:58 → 10:37:59(오류, 10:37:00이 되어야 함)

## 변경 내용
- GpsLogItem 모델에 분(min) 필드 추가
- 타임스탬프에서 분 정보를 추출하여 각 GPS 로그 항목에 저장
- 백엔드에서 정확한 타임스탬프 재구성을 위한 데이터 구조 개선
